### PR TITLE
fix: filter query by user-specified minimum number of products sold n…

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -277,7 +277,8 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                # use function since you cannot filter on computed property
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Fetch products meeting user-specified query number_sold, where number_sold is the minimum amount of products sold.

## Changes

- return correct products meeting user-specified minimum number of products sold


## Requests / Responses

**Request**

GET `http://localhost:8000/products?number_sold=2` 

**Response**

HTTP/1.1 201 OK

```json
[
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
]
```

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database

Provided authenticated user token then make  a `GET` request to

 `http://localhost:8000/products?number_sold=2` 


## Related Issues

- Closes #21 