### PR TITLE
fix: user can delete lineitem from cart. Closes #20.

### DIFF
--- a/bangazon.session.sql
+++ b/bangazon.session.sql
@@ -32,7 +32,6 @@ SELECT *
 FROM bangazonapi_product
 ORDER BY price DESC
 LIMIT 5;
-
 SELECT p.id,
  p.name,
  p.price,
@@ -41,3 +40,22 @@ SELECT p.id,
 FROM bangazonapi_product p
 WHERE price <= 999
 ORDER BY price DESC;
+/*
+ Confirm user ids and customer ids.
+ */
+SELECT c.id AS customer_record,
+ c.user_id AS customer_user_id,
+ t.user_id AS token_user_id,
+ u.id AS auth_user_id,
+ t.key AS token,
+ u.username,
+ u.first_name,
+ u.last_name
+FROM bangazonapi_customer c
+ INNER JOIN authtoken_token t ON t.user_id = c.user_id
+ INNER JOIN auth_user u ON u.id = t.user_id;
+/*
+ For delete lineitem from cart.
+ */
+SELECT *
+FROM bangazonapi_product;

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -18,6 +18,7 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
         )
         fields = ('id', 'url', 'order', 'product')
 
+
 class LineItems(ViewSet):
     """Line items for Bangazon orders"""
 
@@ -51,9 +52,11 @@ class LineItems(ViewSet):
         try:
             # line_item = OrderProduct.objects.get(pk=pk)
             customer = Customer.objects.get(user=request.auth.user)
-            line_item = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            line_item = OrderProduct.objects.get(
+                pk=pk, order__customer=customer)
 
-            serializer = LineItemSerializer(line_item, context={'request': request})
+            serializer = LineItemSerializer(
+                line_item, context={'request': request})
 
             return Response(serializer.data)
 
@@ -76,7 +79,10 @@ class LineItems(ViewSet):
         """
         try:
             customer = Customer.objects.get(user=request.auth.user)
-            order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product = OrderProduct.objects.get(
+                pk=pk, order__customer=customer)
+
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
User can delete lineitem from cart.

## Changes

- Update destroy method so  user can remove lineitem from cart.


## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

DELETE `http://localhost:8000/lineitems/12` Deletes lineitem.

**Response**

```json
{}
```

## Testing

Description of how to test code...

### Postman

DELETE `http://localhost:8000/lineitems/n` Deletes lineitem.

where name is the lineitem id.

## Related Issues

- Closes #20 
