### PR TITLE
fix: user see correct payment type when hitting endpoint /paymenttype…

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -79,13 +79,13 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
+        user = Customer.objects.get(user=request.auth.user)
 
-        customer_id = self.request.query_params.get('customer', None)
+        if user is not None:
+            payment_types = Payment.objects.filter(customer__id=user.id)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+            serializer = PaymentSerializer(
+                payment_types, many=True, context={'request': request})
+            return Response(serializer.data)
 
-        serializer = PaymentSerializer(
-            payment_types, many=True, context={'request': request})
-        return Response(serializer.data)
+        return Response({}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
User see correct payment type when hitting endpoint /paymenttypes . 

## Changes

- Updated payment to only return payment types for requsting user.

## Requests / Responses


**Request**

GET `/paymenttypes` .


**Response**

HTTP/1.1 201 OK

```json
    {
        "id": 3,
        "url": "http://localhost:8000/paymenttypes/3",
        "merchant_name": "Visa",
        "account_number": "fj0398fjw0g89434",
        "expiration_date": "2020-03-01",
        "create_date": "2019-03-11"
    }
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


### Postman

Make a `GET` reqeust to `/paymenttypes` to see user's payment types.

## Related Issues

- Closes #18